### PR TITLE
Refine onboarding screens with Tailwind layout

### DIFF
--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+export default function Button({ children, className = '', ...props }) {
+  return (
+    <button
+      className={`w-full h-11 rounded-lg bg-primary text-white font-medium flex items-center justify-center ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+export default function Input({ className = '', ...props }) {
+  return (
+    <input
+      className={`w-full px-3 py-2 text-sm border border-gray-300 rounded-lg bg-gray-50 mb-4 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/src/components/atoms/StatusBar.jsx
+++ b/src/components/atoms/StatusBar.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function StatusBar() {
+  return (
+    <div className="flex justify-between text-xs text-gray-500 px-4 py-2">
+      <span>9:41</span>
+      <span>🔋</span>
+    </div>
+  );
+}

--- a/src/components/layout/MobileLayout.jsx
+++ b/src/components/layout/MobileLayout.jsx
@@ -1,10 +1,8 @@
-// src/components/MobileLayout.jsx
+// src/components/layout/MobileLayout.jsx
 export default function MobileLayout({ children }) {
   return (
-    <div className="mobile-screen fade-in">
-      <div className="screen-container">
-        {children}
-      </div>
+    <div className="w-full max-w-[375px] min-h-screen mx-auto flex flex-col bg-white fade-in">
+      <div className="flex-1 overflow-y-auto pb-20">{children}</div>
     </div>
   );
 }

--- a/src/components/molecules/PageHeader.jsx
+++ b/src/components/molecules/PageHeader.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { HiArrowLeft } from 'react-icons/hi';
+import { useNavigate } from 'react-router-dom';
+
+
+export default function PageHeader({ title, back = true }) {
+  const navigate = useNavigate();
+  return (
+    <div className="flex items-center gap-4 mb-5">
+      {back && (
+        <button
+          className="text-2xl text-primary hover:text-primary-dark"
+          onClick={() => navigate(-1)}
+        >
+          <HiArrowLeft />
+        </button>
+      )}
+      <h2 className="flex-1 m-0 text-lg font-semibold text-text-primary">
+        {title}
+      </h2>
+    </div>
+  );
+}

--- a/src/components/molecules/SectionCard.jsx
+++ b/src/components/molecules/SectionCard.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function SectionCard({ children, className = '' }) {
+  return (
+    <div className={`bg-gray-50 border border-gray-200 rounded-lg p-4 mb-4 ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/organisms/BottomNav.jsx
+++ b/src/components/organisms/BottomNav.jsx
@@ -14,21 +14,18 @@ export default function BottomNav() {
   const location = useLocation();
 
   return (
-    <div className="fixed bottom-0 left-1/2 w-full max-w-[375px] -translate-x-1/2 bg-white border-t border-gray-200 flex justify-around py-3 z-50">
+    <div className="fixed bottom-0 left-1/2 w-full max-w-[375px] -translate-x-1/2 bg-white/90 backdrop-blur-md shadow-[0_-2px_8px_rgba(0,0,0,0.08)] border-t border-gray-200 flex justify-around py-2 z-50 rounded-t-xl">
       {navItems.map(({ icon: IconComponent, label, path }) => {
         const Icon = IconComponent;
+        const active = location.pathname === path;
         return (
           <button
             key={path}
             onClick={() => navigate(path)}
-            className="flex flex-col items-center gap-1 text-xs focus:outline-none"
+            className={`flex flex-col items-center gap-0.5 text-xs font-medium px-3 py-1 rounded-md ${active ? 'text-primary bg-primary/10' : 'text-gray-500 hover:text-primary'}`}
           >
-            <Icon
-              className={`text-xl ${location.pathname === path ? 'text-primary' : 'text-gray-500'}`}
-            />
-            <span className={location.pathname === path ? 'text-primary' : 'text-gray-500'}>
-              {label}
-            </span>
+            <Icon className="text-xl" />
+            <span>{label}</span>
           </button>
         );
       })}

--- a/src/pages/AboutHabrio.jsx
+++ b/src/pages/AboutHabrio.jsx
@@ -1,30 +1,14 @@
-import { useNavigate } from 'react-router-dom';
+
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function AboutHabrio() {
-  const navigate = useNavigate();
 
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          About Habrio
-        </h2>
-      </div>
+      <PageHeader title="About Habrio" />
 
       {/* App Logo & Info */}
       <div style={{

--- a/src/pages/AddMoney.jsx
+++ b/src/pages/AddMoney.jsx
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
+import Button from '../components/atoms/Button';
+import Input from '../components/atoms/Input';
+import SectionCard from '../components/molecules/SectionCard';
 
 export default function AddMoney() {
   const navigate = useNavigate();
@@ -59,224 +63,88 @@ export default function AddMoney() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Add Money
-        </h2>
-      </div>
+      <PageHeader title="Add Money" />
 
       {/* Add Money Card */}
-      <div style={{
-        background: 'var(--primary-gradient)',
-        borderRadius: '16px',
-        padding: '24px',
-        marginBottom: '24px',
-        color: 'white',
-        textAlign: 'center'
-      }}>
-        <div style={{ fontSize: '48px', marginBottom: '16px' }}>💰</div>
-        <h3 style={{ margin: '0 0 8px 0', fontSize: '18px', fontWeight: '600' }}>
-          Add Money to Wallet
-        </h3>
-        <p style={{ margin: 0, fontSize: '14px', opacity: 0.9 }}>
-          Secure and instant wallet recharge
-        </p>
+      <div className="bg-gradient-to-r from-primary to-primary-dark rounded-xl p-6 mb-6 text-white text-center">
+        <div className="text-5xl mb-4">💰</div>
+        <h3 className="font-semibold text-lg mb-1">Add Money to Wallet</h3>
+        <p className="text-sm opacity-90">Secure and instant wallet recharge</p>
       </div>
 
       {/* Amount Input */}
-      <div style={{
-        background: 'var(--background-soft)',
-        border: '1px solid var(--divider)',
-        borderRadius: '12px',
-        padding: '20px',
-        marginBottom: '24px'
-      }}>
-        <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: '600' }}>
-          Enter Amount
-        </h3>
-        
-        <div style={{ position: 'relative', marginBottom: '16px' }}>
-          <span style={{
-            position: 'absolute',
-            left: '16px',
-            top: '50%',
-            transform: 'translateY(-50%)',
-            fontSize: '18px',
-            fontWeight: '600',
-            color: 'var(--text-secondary)'
-          }}>
-            ₹
-          </span>
-          <input
+      <SectionCard>
+        <h3 className="font-semibold text-base mb-4">Enter Amount</h3>
+        <div className="relative mb-4">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-lg font-semibold text-text-secondary">₹</span>
+          <Input
             type="number"
             placeholder="0"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '16px 16px 16px 40px',
-              border: '1px solid var(--divider)',
-              borderRadius: '12px',
-              fontSize: '20px',
-              fontWeight: '600',
-              textAlign: 'center',
-              background: 'white'
-            }}
+            className="pl-10 text-xl font-semibold text-center bg-white"
           />
         </div>
-
-        {/* Quick Amount Buttons */}
-        <div>
-          <p style={{ margin: '0 0 12px 0', fontSize: '14px', fontWeight: '500', color: 'var(--text-secondary)' }}>
-            Quick Select
-          </p>
-          <div style={{ 
-            display: 'grid', 
-            gridTemplateColumns: 'repeat(3, 1fr)', 
-            gap: '8px'
-          }}>
-            {quickAmounts.map((quickAmount) => (
-              <button
-                key={quickAmount}
-                onClick={() => handleQuickAmount(quickAmount)}
-                style={{
-                  background: amount === quickAmount.toString() ? 'var(--primary-gradient)' : 'white',
-                  color: amount === quickAmount.toString() ? 'white' : 'var(--text-primary)',
-                  border: amount === quickAmount.toString() ? 'none' : '1px solid var(--divider)',
-                  borderRadius: '8px',
-                  padding: '12px 8px',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  cursor: 'pointer'
-                }}
-              >
-                ₹{quickAmount}
-              </button>
-            ))}
-          </div>
+        <p className="text-sm font-medium text-text-secondary mb-3">Quick Select</p>
+        <div className="grid grid-cols-3 gap-2">
+          {quickAmounts.map((quickAmount) => (
+            <button
+              key={quickAmount}
+              onClick={() => handleQuickAmount(quickAmount)}
+              className={`rounded-md py-2 text-sm font-medium border ${amount === quickAmount.toString() ? 'bg-primary text-white border-primary' : 'bg-white text-text-primary border-gray-300'}`}
+            >
+              ₹{quickAmount}
+            </button>
+          ))}
         </div>
-      </div>
+      </SectionCard>
 
       {/* Payment Methods */}
-      <div style={{
-        background: 'var(--background-soft)',
-        border: '1px solid var(--divider)',
-        borderRadius: '12px',
-        padding: '20px',
-        marginBottom: '24px'
-      }}>
-        <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: '600' }}>
-          Payment Method
-        </h3>
-        
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-          <div style={{
-            background: 'white',
-            border: '2px solid var(--primary-color)',
-            borderRadius: '8px',
-            padding: '16px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px'
-          }}>
-            <div style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '50%',
-              background: 'var(--primary-color)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
-              <div style={{
-                width: '8px',
-                height: '8px',
-                borderRadius: '50%',
-                background: 'white'
-              }}></div>
+      <SectionCard>
+        <h3 className="font-semibold text-base mb-4">Payment Method</h3>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3 p-4 border-2 border-primary rounded-lg bg-white">
+            <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
+              <div className="w-2 h-2 rounded-full bg-white" />
             </div>
-            <div style={{ flex: 1 }}>
-              <p style={{ margin: '0 0 2px 0', fontSize: '14px', fontWeight: '600' }}>
-                💳 UPI / Cards / NetBanking
-              </p>
-              <p style={{ margin: 0, fontSize: '12px', color: 'var(--text-secondary)' }}>
-                Pay securely using UPI, Debit/Credit cards or NetBanking
-              </p>
+            <div className="flex-1">
+              <p className="font-semibold text-sm mb-0">💳 UPI / Cards / NetBanking</p>
+              <p className="text-xs text-text-secondary">Pay securely using UPI, Debit/Credit cards or NetBanking</p>
             </div>
           </div>
         </div>
-      </div>
+      </SectionCard>
 
       {/* Security Notice */}
-      <div style={{
-        background: 'rgba(0, 199, 117, 0.1)',
-        border: '1px solid rgba(0, 199, 117, 0.2)',
-        borderRadius: '12px',
-        padding: '16px',
-        marginBottom: '24px'
-      }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
-          <span style={{ fontSize: '16px', marginTop: '2px' }}>🔒</span>
+      <SectionCard className="border-green-200 bg-green-50">
+        <div className="flex items-start gap-3">
+          <span className="text-lg mt-0.5">🔒</span>
           <div>
-            <h4 style={{ margin: '0 0 4px 0', fontSize: '14px', fontWeight: '600', color: 'var(--success-color)' }}>
-              100% Secure Payment
-            </h4>
-            <ul style={{ margin: 0, paddingLeft: '16px', fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.4' }}>
+            <h4 className="font-semibold text-sm text-green-600 mb-1">100% Secure Payment</h4>
+            <ul className="list-disc pl-4 text-xs text-text-secondary space-y-1">
               <li>All transactions are encrypted and secure</li>
               <li>Money will be instantly added to your wallet</li>
               <li>No additional charges or hidden fees</li>
             </ul>
           </div>
         </div>
-      </div>
+      </SectionCard>
 
       {/* Add Money Button */}
-      <button
+      <Button
         onClick={addMoney}
         disabled={loading || !amount || parseFloat(amount) < 1}
-        style={{
-          background: loading || !amount || parseFloat(amount) < 1 
-            ? 'var(--text-disabled)' 
-            : 'var(--primary-gradient)',
-          color: 'white',
-          border: 'none',
-          borderRadius: '12px',
-          padding: '16px',
-          fontSize: '18px',
-          fontWeight: '600',
-          cursor: loading || !amount || parseFloat(amount) < 1 ? 'not-allowed' : 'pointer',
-          width: '100%',
-          marginBottom: '20px',
-          opacity: loading || !amount || parseFloat(amount) < 1 ? 0.6 : 1
-        }}
+        className={`mb-5 ${loading || !amount || parseFloat(amount) < 1 ? 'bg-text-disabled cursor-not-allowed opacity-60' : 'bg-gradient-to-r from-primary to-primary-dark'}`}
       >
         {loading ? 'Processing...' : `Add ₹${amount || '0'} to Wallet`}
-      </button>
+      </Button>
 
       {/* Terms */}
-      <p style={{ 
-        margin: '0 0 20px 0', 
-        fontSize: '11px', 
-        color: 'var(--text-secondary)', 
-        textAlign: 'center',
-        lineHeight: '1.4'
-      }}>
+      <p className="text-[11px] text-text-secondary text-center leading-tight mb-5">
         By proceeding, you agree to our{' '}
-        <span style={{ color: 'var(--primary-color)', fontWeight: '500' }}>Terms & Conditions</span>
+        <span className="text-primary font-medium">Terms & Conditions</span>
         {' '}and{' '}
-        <span style={{ color: 'var(--primary-color)', fontWeight: '500' }}>Refund Policy</span>
+        <span className="text-primary font-medium">Refund Policy</span>
       </p>
 
       {/* Bottom Navigation Placeholder */}

--- a/src/pages/BasicOnboarding.jsx
+++ b/src/pages/BasicOnboarding.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import '../styles/common.css';
-import '../styles/App.css';
+import MobileLayout from '../components/layout/MobileLayout';
+import StatusBar from '../components/atoms/StatusBar';
+import Button from '../components/atoms/Button';
+import Input from '../components/atoms/Input';
 
 export default function BasicOnboarding() {
   const navigate = useNavigate();
@@ -49,47 +51,39 @@ export default function BasicOnboarding() {
   };
 
   return (
-    <div className="mobile-screen fade-in">
-      <div className="status-bar">
-        <span className="time">9:41</span>
-        <span className="battery">🔋</span>
-      </div>
-      <div className="screen-content">
-        <h2 className="title text-center mb-lg">Tell us about yourself</h2>
-        <div className="form-group">
-          <label className="form-label">Full Name</label>
-          <input
+    <MobileLayout>
+      <StatusBar />
+      <div className="px-6 py-10">
+        <h2 className="text-center text-xl font-semibold mb-8">Tell us about yourself</h2>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Full Name</label>
+          <Input
             name="name"
-            className="form-input"
             placeholder="Ashish Dabas"
             value={data.name}
             onChange={handleChange}
           />
         </div>
-        <div className="form-group">
-          <label className="form-label">City</label>
-          <input
+        <div className="mb-4">
+          <label className="block mb-1 text-sm font-medium text-gray-700">City</label>
+          <Input
             name="city"
-            className="form-input"
             placeholder="Noida"
             value={data.city}
             onChange={handleChange}
           />
         </div>
-        <div className="form-group">
-          <label className="form-label">Society</label>
-          <input
+        <div className="mb-6">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Society</label>
+          <Input
             name="society"
-            className="form-input"
             placeholder="Hyde Park"
             value={data.society}
             onChange={handleChange}
           />
         </div>
-        <button className="btn btn-primary btn-full btn-large" onClick={submit}>
-          Complete
-        </button>
+        <Button onClick={submit}>Complete</Button>
       </div>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function Cart() {
   const navigate = useNavigate();
@@ -127,23 +128,8 @@ export default function Cart() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600', flex: 1 }}>
-          My Cart ({cartItems.length})
-        </h2>
-        {cartItems.length > 0 && (
+      <PageHeader title={`My Cart (${cartItems.length})`} />
+      {cartItems.length > 0 && (
           <button
             onClick={clearCart}
             style={{
@@ -158,7 +144,6 @@ export default function Cart() {
             Clear All
           </button>
         )}
-      </div>
 
       {cartItems.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '40px 20px' }}>

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function Checkout() {
   const navigate = useNavigate();
@@ -118,23 +119,7 @@ export default function Checkout() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Checkout
-        </h2>
-      </div>
+      <PageHeader title="Checkout" />
 
       {/* Delivery Address */}
       <div style={{

--- a/src/pages/ConsumerOnboarding.jsx
+++ b/src/pages/ConsumerOnboarding.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import '../styles/common.css';
-import '../styles/App.css';
+import MobileLayout from '../components/layout/MobileLayout';
+import StatusBar from '../components/atoms/StatusBar';
+import Button from '../components/atoms/Button';
+import Input from '../components/atoms/Input';
 
 export default function ConsumerOnboarding() {
   const navigate = useNavigate();
@@ -36,26 +38,20 @@ export default function ConsumerOnboarding() {
   };
 
   return (
-    <div className="mobile-screen fade-in">
-      <div className="status-bar">
-        <span className="time">9:41</span>
-        <span className="battery">🔋</span>
-      </div>
-      <div className="screen-content">
-        <h2 className="title text-center mb-lg">Your Home Address</h2>
-        <div className="form-group">
-          <label className="form-label">Flat / House Number</label>
-          <input
-            className="form-input"
+    <MobileLayout>
+      <StatusBar />
+      <div className="px-6 py-10">
+        <h2 className="text-center text-xl font-semibold mb-8">Your Home Address</h2>
+        <div className="mb-6">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Flat / House Number</label>
+          <Input
             placeholder="e.g., A-302"
             value={flatNumber}
             onChange={e => setFlatNumber(e.target.value.trimStart())}
           />
         </div>
-        <button className="btn btn-primary btn-full btn-large" onClick={submit}>
-          Complete
-        </button>
+        <Button onClick={submit}>Complete</Button>
       </div>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -85,15 +85,15 @@ function Home() {
   return (
     <div className="screen-content px-4 py-4">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-6 bg-gradient-to-r from-primary to-primary-dark text-white p-4 rounded-xl">
         <div>
           <h2 className="text-xl font-semibold">Hello, {userProfile?.name || 'User'}! 👋</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <p className="text-sm text-white/80 mt-1">
             {userProfile?.society}, {userProfile?.city}
           </p>
         </div>
         <button
-          className="w-10 h-10 rounded-full bg-gradient-to-r from-green-400 to-blue-500 flex items-center justify-center text-white text-lg"
+          className="w-10 h-10 rounded-full bg-white/20 flex items-center justify-center text-white text-lg"
           onClick={() => navigate('/profile')}
         >
           <HiUser />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import '../styles/common.css';
-import '../styles/App.css';
+import MobileLayout from '../components/layout/MobileLayout';
+import StatusBar from '../components/atoms/StatusBar';
+import Button from '../components/atoms/Button';
 
 export default function Login() {
   const [phone, setPhone] = useState('');
@@ -31,61 +32,34 @@ export default function Login() {
   };
 
   return (
-    <div className="mobile-screen fade-in">
-      <div className="status-bar">
-        <span className="time">9:41</span>
-        <span className="battery">🔋</span>
-      </div>
-      <div className="screen-content">
-        <div className="text-center mb-lg" style={{ paddingTop: 48 }}>
-          <div
-            style={{
-              background: 'var(--primary-gradient)',
-              width: 80,
-              height: 80,
-              borderRadius: 20,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              margin: '0 auto 24px',
-              boxShadow: '0 8px 18px rgba(255, 145, 0, 0.35)',
-            }}
-          >
-            <span style={{ fontSize: 36, color: 'white' }}>📲</span>
+    <MobileLayout>
+      <StatusBar />
+      <div className="px-6 pt-12">
+        <div className="text-center mb-8">
+          <div className="w-20 h-20 rounded-2xl bg-gradient-to-r from-primary to-primary-dark flex items-center justify-center mx-auto mb-6 shadow-lg">
+            <span className="text-3xl text-white">📲</span>
           </div>
-          <h2 className="title" style={{ fontSize: 22 }}>Log in to Habrio</h2>
-          <p className="subtitle">Enter your mobile number to continue</p>
+          <h2 className="text-xl font-semibold mb-1">Log in to Habrio</h2>
+          <p className="text-sm text-gray-500">Enter your mobile number to continue</p>
         </div>
-        <div className="form-group mb-md">
-          <div className="phone-input-group">
-            <div className="country-code">+91</div>
-            <input
-              type="tel"
-              className="phone-input"
-              placeholder="9876543210"
-              maxLength="10"
-              value={phone}
-              onChange={e => setPhone(e.target.value)}
-            />
-          </div>
+        <div className="flex items-center bg-gray-50 border border-gray-300 rounded-lg px-3 mb-6 h-11">
+          <span className="text-gray-500 mr-2">+91</span>
+          <input
+            type="tel"
+            placeholder="9876543210"
+            maxLength="10"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            className="flex-1 bg-transparent outline-none text-sm"
+          />
         </div>
-        <button className="btn btn-primary btn-full btn-large" onClick={sendOtp}>
-          Send OTP
-        </button>
-        <p
-          style={{
-            fontSize: 12,
-            color: 'var(--text-secondary)',
-            textAlign: 'center',
-            lineHeight: 1.5,
-            marginTop: 24,
-          }}
-        >
+        <Button onClick={sendOtp}>Send OTP</Button>
+        <p className="text-xs text-gray-500 text-center mt-6">
           By continuing, you agree to our{' '}
-          <a href="#" className="link">Terms & Conditions</a> and{' '}
-          <a href="#" className="link">Privacy Policy</a>
+          <a href="#" className="text-primary font-medium">Terms & Conditions</a> and{' '}
+          <a href="#" className="text-primary font-medium">Privacy Policy</a>
         </p>
       </div>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/pages/OrderDetail.jsx
+++ b/src/pages/OrderDetail.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function OrderDetail() {
   const { orderId } = useParams();
@@ -156,23 +157,7 @@ export default function OrderDetail() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600', flex: 1 }}>
-          Order #{order.order_id}
-        </h2>
-      </div>
+      <PageHeader title={`Order #${order.order_id}`} />
 
       {/* Order Status */}
       <div style={{

--- a/src/pages/OrderHistory.jsx
+++ b/src/pages/OrderHistory.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function OrderHistory() {
   const navigate = useNavigate();
@@ -88,23 +89,7 @@ export default function OrderHistory() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          My Orders
-        </h2>
-      </div>
+      <PageHeader title="My Orders" />
 
       {/* Filter Tabs */}
       <div style={{ 

--- a/src/pages/Otp.jsx
+++ b/src/pages/Otp.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import '../styles/common.css';
-import '../styles/App.css';
+import MobileLayout from '../components/layout/MobileLayout';
+import StatusBar from '../components/atoms/StatusBar';
+import Button from '../components/atoms/Button';
+import Input from '../components/atoms/Input';
 
 export default function Otp() {
   const [otp, setOtp] = useState('');
@@ -38,65 +40,30 @@ export default function Otp() {
   };
 
   return (
-    <div className="mobile-screen fade-in">
-      <div className="status-bar">
-        <span className="time">9:41</span>
-        <span className="battery">🔋</span>
-      </div>
-      <div className="screen-content">
-        <div className="text-center mb-lg" style={{ paddingTop: 40 }}>
-          <div
-            style={{
-              background: 'var(--primary-gradient)',
-              width: 72,
-              height: 72,
-              borderRadius: 18,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              margin: '0 auto 20px',
-              boxShadow: '0 6px 16px rgba(255, 125, 30, 0.3)',
-            }}
-          >
-            <span style={{ fontSize: 30, color: 'white' }}>🔐</span>
+    <MobileLayout>
+      <StatusBar />
+      <div className="px-6 pt-10">
+        <div className="text-center mb-6">
+          <div className="bg-gradient-to-r from-primary to-primary-dark w-16 h-16 rounded-xl flex items-center justify-center mx-auto mb-5 shadow-lg">
+            <span className="text-white text-2xl">🔐</span>
           </div>
-          <h2 className="title">Enter OTP</h2>
-          <p className="subtitle">Sent to +91 {phone}</p>
+          <h2 className="text-xl font-semibold">Enter OTP</h2>
+          <p className="text-sm text-gray-500">Sent to +91 {phone}</p>
         </div>
-        <div className="form-group mb-md">
-          <input
-            type="tel"
-            className="otp-input"
-            placeholder="Enter 6-digit code"
-            maxLength="6"
-            value={otp}
-            onChange={e => setOtp(e.target.value)}
-            style={{
-              width: '100%',
-              textAlign: 'center',
-              fontSize: 20,
-              letterSpacing: '4px',
-              padding: 12,
-              border: '1px solid #ccc',
-              borderRadius: 8,
-            }}
-          />
-        </div>
-        <button className="btn btn-primary btn-full btn-large" onClick={verifyOtp}>
-          Verify OTP
-        </button>
-        <p
-          style={{
-            fontSize: 12,
-            color: 'var(--text-secondary)',
-            textAlign: 'center',
-            marginTop: 20,
-          }}
-        >
+        <Input
+          type="tel"
+          placeholder="Enter 6-digit code"
+          maxLength="6"
+          value={otp}
+          onChange={e => setOtp(e.target.value)}
+          className="text-center text-xl tracking-widest mb-6"
+        />
+        <Button onClick={verifyOtp}>Verify OTP</Button>
+        <p className="text-xs text-gray-500 text-center mt-5">
           Didn’t receive the code?{' '}
-          <a href="#" className="link">Resend</a>
+          <a href="#" className="text-primary font-medium">Resend</a>
         </p>
       </div>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function Profile() {
   const navigate = useNavigate();
@@ -111,22 +112,8 @@ export default function Profile() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600', flex: 1 }}>
-          My Profile
-        </h2>
+      <div className="flex items-center justify-between mb-6">
+        <PageHeader title="My Profile" />
         {!editing && (
           <button
             onClick={handleEdit}

--- a/src/pages/RateOrder.jsx
+++ b/src/pages/RateOrder.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function RateOrder() {
   const { orderId } = useParams();
@@ -143,23 +144,7 @@ export default function RateOrder() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Rate Your Order
-        </h2>
-      </div>
+      <PageHeader title="Rate Your Order" />
 
       {/* Rating Header */}
       <div style={{

--- a/src/pages/SearchShops.jsx
+++ b/src/pages/SearchShops.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function SearchShops() {
   const navigate = useNavigate();
@@ -67,23 +68,7 @@ export default function SearchShops() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Search Shops
-        </h2>
-      </div>
+      <PageHeader title="Search Shops" />
 
       {/* Search Bar */}
       <form onSubmit={handleSearch} style={{ marginBottom: '24px' }}>

--- a/src/pages/ShopDetail.jsx
+++ b/src/pages/ShopDetail.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function ShopDetail() {
   const { shopId } = useParams();
@@ -103,23 +104,8 @@ export default function ShopDetail() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600', flex: 1 }}>
-          {shop?.shop_name}
-        </h2>
-        {cartCount > 0 && (
+      <PageHeader title={shop?.shop_name || 'Shop'} />
+      {cartCount > 0 && (
           <button
             onClick={() => navigate('/cart')}
             style={{
@@ -153,7 +139,6 @@ export default function ShopDetail() {
             </span>
           </button>
         )}
-      </div>
 
       {/* Shop Info */}
       <div style={{

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function Support() {
   const navigate = useNavigate();
@@ -58,23 +59,7 @@ export default function Support() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Help & Support
-        </h2>
-      </div>
+      <PageHeader title="Help & Support" />
 
       {/* Support Header */}
       <div style={{

--- a/src/pages/TitleScreen.jsx
+++ b/src/pages/TitleScreen.jsx
@@ -1,56 +1,25 @@
 import { useNavigate } from 'react-router-dom';
-import '../styles/common.css';
-import '../styles/App.css';
+import MobileLayout from '../components/layout/MobileLayout';
+import StatusBar from '../components/atoms/StatusBar';
+import Button from '../components/atoms/Button';
 
 export default function TitleScreen() {
   const navigate = useNavigate();
 
   return (
-    <div className="mobile-screen fade-in">
-      <div className="status-bar">
-        <span className="time">9:41</span>
-        <span className="battery">🔋</span>
-      </div>
-      <div className="screen-content text-center">
-        <div
-          className="logo-box"
-          style={{
-            background: 'var(--primary-gradient)',
-            width: 84,
-            height: 84,
-            borderRadius: 24,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            margin: '0 auto 24px',
-            boxShadow: '0 6px 14px rgba(255, 125, 30, 0.3)'
-          }}
-        >
-          <span className="logo-icon" style={{ fontSize: 36, color: '#fff' }}>🏘️</span>
+    <MobileLayout>
+      <StatusBar />
+      <div className="flex flex-col items-center text-center px-6 pt-12">
+        <div className="w-20 h-20 rounded-2xl bg-gradient-to-r from-primary to-primary-dark flex items-center justify-center mb-6 shadow-lg">
+          <span className="text-3xl text-white">🏘️</span>
         </div>
-        <h1 className="title mb-xs" style={{ fontSize: 24 }}>
-          Welcome to Habrio
-        </h1>
-        <p className="subtitle mb-lg" style={{ fontSize: 14 }}>
-          Your society’s very own super app
-        </p>
-        <button
-          className="btn btn-primary btn-full btn-large"
-          style={{ marginBottom: 24 }}
-          onClick={() => navigate('/login')}
-        >
+        <h1 className="text-2xl font-semibold mb-2">Welcome to Habrio</h1>
+        <p className="text-sm text-gray-500 mb-8">Your society’s very own super app</p>
+        <Button className="mb-6" onClick={() => navigate('/login')}>
           Get Started
-        </button>
-        <p
-          className="text-center"
-          style={{
-            fontSize: 12,
-            color: 'var(--text-tertiary)',
-          }}
-        >
-          Built with ❤️ for your neighbourhood
-        </p>
+        </Button>
+        <p className="text-xs text-gray-400">Built with ❤️ for your neighbourhood</p>
       </div>
-    </div>
+    </MobileLayout>
   );
 }

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function Wallet() {
   const navigate = useNavigate();
@@ -92,23 +93,7 @@ export default function Wallet() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          My Wallet
-        </h2>
-      </div>
+      <PageHeader title="My Wallet" />
 
       {/* Wallet Balance Card */}
       <div style={{

--- a/src/pages/WalletHistory.jsx
+++ b/src/pages/WalletHistory.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/common.css';
 import '../styles/App.css';
+import PageHeader from '../components/molecules/PageHeader';
 
 export default function WalletHistory() {
   const navigate = useNavigate();
@@ -84,23 +85,7 @@ export default function WalletHistory() {
   return (
     <div className="screen-content">
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '20px' }}>
-        <button
-          onClick={() => navigate(-1)}
-          style={{
-            background: 'none',
-            border: 'none',
-            fontSize: '24px',
-            marginRight: '16px',
-            cursor: 'pointer'
-          }}
-        >
-          ←
-        </button>
-        <h2 style={{ margin: 0, fontSize: '20px', fontWeight: '600' }}>
-          Transaction History
-        </h2>
-      </div>
+      <PageHeader title="Transaction History" />
 
       {/* Filter Tabs */}
       <div style={{ 


### PR DESCRIPTION
## Summary
- replace custom wrappers with MobileLayout and StatusBar atoms
- convert Title, Login, OTP and onboarding pages to Tailwind
- tweak Home page header with gradient styling

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882b830a6f08333b871032f44686f2a