### PR TITLE
Fix Tailwind build and show bottom navigation

### DIFF
--- a/src/components/layout/MobileLayout.jsx
+++ b/src/components/layout/MobileLayout.jsx
@@ -1,6 +1,8 @@
 // File: src/components/layout/MobileLayout.jsx
 import React from 'react';
 import clsx from 'clsx';
+import { useNavigate } from 'react-router-dom';
+import BottomNav from '../organisms/BottomNav';
 
 /**
  * MobileLayout wrapper
@@ -9,18 +11,34 @@ import clsx from 'clsx';
  * - children: page content
  * - className: additional Tailwind utility classes
  */
-export default function MobileLayout({ children, className = '' }) {
+export default function MobileLayout({
+  children,
+  className = '',
+  showNav = false,
+  activeTab = 'home',
+}) {
+  const navigate = useNavigate();
+
+  const paddingY = showNav ? 'pt-4 pb-20' : 'pt-4 pb-4';
+
   return (
     <div
       className={clsx(
         'min-h-screen bg-background flex justify-center items-start',
-        'pt-4 pb-20', // top padding and bottom padding for fixed bottom nav
+        paddingY,
         className
       )}
     >
       <div className="w-full max-w-md px-4">
         {children}
       </div>
+      {showNav && (
+        <BottomNav
+          active={activeTab}
+          onNavigate={(route) => navigate(route)}
+          className="max-w-md mx-auto"
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -48,7 +48,7 @@ export default function Cart() {
 
   if (loading) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="cart">
         <PageHeader title="My Cart" />
         <ScreenContainer>
           <div className="flex flex-col items-center py-12">
@@ -62,7 +62,7 @@ export default function Cart() {
 
   if (items.length === 0) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="cart">
         <PageHeader title="My Cart" />
         <ScreenContainer>
           <EmptyState
@@ -78,7 +78,7 @@ export default function Cart() {
   }
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="cart">
       <PageHeader title={`My Cart (${items.length})`} />
       <ScreenContainer>
         <div className="flex justify-end mb-4 px-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -81,7 +81,7 @@ export default function Home() {
 
   if (loading) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="home">
         <ScreenContainer>
           <div className="flex items-center justify-center h-screen">
             <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-primary"></div>
@@ -92,7 +92,7 @@ export default function Home() {
   }
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="home">
       <ScreenContainer className="px-4 py-6 space-y-6">
         {/* Hero Section */}
         <HeroSection

--- a/src/pages/OrderHistory.jsx
+++ b/src/pages/OrderHistory.jsx
@@ -54,7 +54,7 @@ export default function OrderHistory() {
 
   if (loading) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="orders">
         <PageHeader title="My Orders" />
         <ScreenContainer className="flex-center">
           <Spinner size={40} className="text-primary" />
@@ -65,7 +65,7 @@ export default function OrderHistory() {
 
   if (filtered.length === 0) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="orders">
         <PageHeader title="My Orders" />
         <ScreenContainer>
           <EmptyState
@@ -85,7 +85,7 @@ export default function OrderHistory() {
   }
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="orders">
       <PageHeader title="My Orders" />
       <ScreenContainer className="space-y-4">
         <TabSelector

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -73,7 +73,7 @@ export default function Profile() {
 
   if (loading) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="profile">
         <PageHeader title="My Profile" />
         <ScreenContainer className="flex justify-center py-20">
           <Spinner size={48} className="text-primary" />
@@ -84,7 +84,7 @@ export default function Profile() {
 
   if (!profile) {
     return (
-      <MobileLayout>
+      <MobileLayout showNav activeTab="profile">
         <PageHeader title="My Profile" />
         <ScreenContainer className="py-20">
           <EmptyState
@@ -99,7 +99,7 @@ export default function Profile() {
   }
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="profile">
       <PageHeader title="My Profile" />
       <ScreenContainer className="space-y-6">
         {!editing && (

--- a/src/pages/SearchShops.jsx
+++ b/src/pages/SearchShops.jsx
@@ -61,7 +61,7 @@ export default function SearchShops() {
   }
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="shops">
       <PageHeader title="Search Shops" />
       <ScreenContainer className="space-y-6">
         {/* Search Bar */}

--- a/src/pages/ShopList.jsx
+++ b/src/pages/ShopList.jsx
@@ -47,7 +47,7 @@ export default function ShopList() {
     : 'All Shops';
 
   return (
-    <MobileLayout>
+    <MobileLayout showNav activeTab="shops">
       <PageHeader back={() => navigate(-1)} title={title} />
       <ScreenContainer>
         {loading ? (

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .safe-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}


### PR DESCRIPTION
## Summary
- add bottom navigation support in `MobileLayout`
- display bottom navigation on main pages
- expose safe area utility class

## Testing
- `npm run lint` *(fails: Component issues and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883ccd2b3688333ae1e2700989312b7