### PR TITLE
Fix crash on cart page

### DIFF
--- a/src/components/organisms/CartItemCard.jsx
+++ b/src/components/organisms/CartItemCard.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import clsx from 'clsx';
 import Button from '../atoms/Button';
 import { Heading, BodyText } from '../atoms/Typography';
+import Badge from '../atoms/Badge';
+
+// Default currency symbol used for price display
+const currencySymbol = '₹';
 
 /**
  * CartItemCard organism


### PR DESCRIPTION
## Summary
- add missing `Badge` import and define `currencySymbol` constant in `CartItemCard` to prevent runtime errors

## Testing
- `npm run lint` *(fails: various pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884e4e98e8c83338126b0b17427b53d