### PR TITLE
feat: update API routes for v1 backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://2e6bee57-c137-4144-90f2-64265943227d-00-c6d7jiueybzk.pike.replit.dev
+VITE_BACKEND_URL=https://2e6bee57-c137-4144-90f2-64265943227d-00-c6d7jiueybzk.pike.replit.dev/api/v1

--- a/src/components/atoms/Typography.jsx
+++ b/src/components/atoms/Typography.jsx
@@ -40,11 +40,12 @@ export function Heading({ level = 1, children, className = "", ...rest }) {
 export function BodyText({
   size = "md",
   color = "primary",
-  as: Component = "p",
+  as = "p",
   className = "",
   children,
   ...rest
 }) {
+  const Tag = as;
   const sizeMap = {
     sm: "text-sm",
     md: "text-base",
@@ -58,12 +59,12 @@ export function BodyText({
     muted: "text-text-secondary opacity-80",
   };
   return (
-    <Component
+    <Tag
       className={clsx(sizeMap[size], colorMap[color], className)}
       {...rest}
     >
       {children}
-    </Component>
+    </Tag>
   );
 }
 

--- a/src/pages/AddMoney.jsx
+++ b/src/pages/AddMoney.jsx
@@ -30,7 +30,7 @@ export default function AddMoney() {
     setLoading(true);
     try {
       const token = localStorage.getItem('auth_token');
-      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/wallet/load`, {
+      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/consumer/wallet/load`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: token },
         body: JSON.stringify({ amount: value, reference: 'Manual wallet top-up' }),

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -27,12 +27,12 @@ export default function Cart() {
   async function fetchCart(token) {
     setLoading(true);
     try {
-      const { status, cart, total_price, total_savings } = await get('/cart/view', { token });
+      const { status, cart, total_price, total_savings } = await get('/consumer/cart/view', { token });
       if (status === 'success') {
         setItems(cart);
         setTotals({ total_price, total_savings });
       }
-    } catch {}
+    } catch { /* ignore */ }
     setLoading(false);
   }
 
@@ -41,9 +41,9 @@ export default function Cart() {
     setClearing(true);
     try {
       const token = localStorage.getItem('auth_token');
-      await post('/cart/clear', null, { token });
+      await post('/consumer/cart/clear', null, { token });
       fetchCart(token);
-    } catch {}
+    } catch { /* ignore */ }
     setClearing(false);
   }
 
@@ -94,12 +94,12 @@ export default function Cart() {
 
         <div className="space-y-4 px-4">
           {items.map(item => (
-            <CartItemCard
-              key={item.id}
-              item={item}
-              onQuantityChange={(qty) => {/* call update API then refresh */}}
-              onRemove={() => {/* call remove API then refresh */}}
-            />
+              <CartItemCard
+                key={item.id}
+                item={item}
+                onQuantityChange={() => { /* call update API then refresh */ }}
+                onRemove={() => { /* call remove API then refresh */ }}
+              />
           ))}
         </div>
 

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -32,7 +32,7 @@ export default function Checkout() {
 
   async function loadCart(token) {
     try {
-      const { status, cart, total_price, total_savings } = await get('/cart/view', { token });
+      const { status, cart, total_price, total_savings } = await get('/consumer/cart/view', { token });
       if (status === 'success') {
         if (cart.length === 0) navigate('/cart');
         setCartItems(cart);
@@ -42,14 +42,14 @@ export default function Checkout() {
           total: total_price,
         });
       }
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function loadWallet(token) {
     try {
-      const { status, balance } = await get('/wallet', { token });
+      const { status, balance } = await get('/consumer/wallet', { token });
       if (status === 'success') setWalletBalance(balance);
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function handlePlaceOrder() {
@@ -60,7 +60,7 @@ export default function Checkout() {
     try {
       const token = localStorage.getItem('auth_token');
       const body = { payment_mode: paymentMode, delivery_notes: deliveryNotes };
-      const { status, order_id, message } = await post('/order/confirm', body, { token });
+      const { status, order_id, message } = await post('/consumer/order/confirm', body, { token });
       if (status === 'success') {
         navigate(`/order/${order_id}`);
       } else {

--- a/src/pages/ConsumerOnboarding.jsx
+++ b/src/pages/ConsumerOnboarding.jsx
@@ -25,7 +25,7 @@ export default function ConsumerOnboarding() {
     }
     setSubmitting(true);
     try {
-      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/onboarding/consumer`, {
+      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/consumer/onboarding`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -30,7 +30,7 @@ export default function Home() {
   const [nearbyShops, setNearbyShops] = useState([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
-  const [searching, setSearching] = useState(false);
+  const [searching] = useState(false);
 
   const shopCategories = [
     { name: 'Grocery', icon: <HiShoppingCart />, type: 'grocery' },
@@ -51,26 +51,26 @@ export default function Home() {
 
   async function fetchProfile() {
     try {
-      const { status, data } = await get('/profile/me');
+      const { status, data } = await get('/consumer/profile/me');
       if (status === 'success') setUser(data);
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function fetchWallet() {
     try {
-      const { status, balance } = await get('/wallet');
+      const { status, balance } = await get('/consumer/wallet');
       if (status === 'success') setWalletBalance(balance);
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function fetchShops() {
     try {
-      const { status, shops } = await get('/shops?status=open');
+      const { status, shops } = await get('/consumer/shops?status=open');
       if (status === 'success') {
         setFeaturedShops(shops.filter((s) => s.featured).slice(0, 3));
         setNearbyShops(shops.slice(0, 6));
       }
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   function handleSearchSubmit(value) {

--- a/src/pages/OrderDetail.jsx
+++ b/src/pages/OrderDetail.jsx
@@ -35,27 +35,27 @@ export default function OrderDetail() {
   async function fetchOrder(token) {
     setLoading(true);
     try {
-      const res = await get('/order/history', { token });
+      const res = await get('/consumer/order/history', { token });
       if (res.status === 'success') {
         const found = res.orders.find(o => `${o.order_id}` === `${orderId}`);
         setOrder(found || null);
       }
-    } catch {}
+    } catch { /* ignore */ }
     setLoading(false);
   }
 
   async function fetchMsgs(token) {
     try {
-      const res = await get(`/order/consumer/messages/${orderId}`, { token });
+      const res = await get(`/consumer/orders/${orderId}/messages`, { token });
       if (res.status === 'success') setMessages(res.messages || []);
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function cancelOrder() {
     if (!window.confirm('Are you sure you want to cancel this order?')) return;
     try {
       const token = localStorage.getItem('auth_token');
-      const res = await post(`/order/consumer/cancel/${orderId}`, {}, { token });
+      const res = await post(`/consumer/orders/${orderId}/cancel`, {}, { token });
       if (res.status === 'success') {
         alert('Order cancelled successfully');
         fetchOrder(token);

--- a/src/pages/OrderHistory.jsx
+++ b/src/pages/OrderHistory.jsx
@@ -31,7 +31,7 @@ export default function OrderHistory() {
 
   async function fetchOrders(token) {
     try {
-      const { status, orders } = await get('/order/history', { token });
+      const { status, orders } = await get('/consumer/order/history', { token });
       if (status === 'success') setOrders(orders);
     } catch {
       // handle error silently

--- a/src/pages/OrderMessages.jsx
+++ b/src/pages/OrderMessages.jsx
@@ -24,7 +24,7 @@ export default function OrderMessages() {
     if (!token) return navigate('/login');
 
     // fetch current user phone
-    get('/profile/me', { token }).then(({ status, data }) => {
+    get('/consumer/profile/me', { token }).then(({ status, data }) => {
       if (status === 'success') setUserPhone(data.phone);
     });
 
@@ -37,7 +37,7 @@ export default function OrderMessages() {
     const token = localStorage.getItem('auth_token');
     try {
       const { status, messages } = await get(
-        `/order/consumer/messages/${orderId}`,
+        `/consumer/orders/${orderId}/messages`,
         { token }
       );
       if (status === 'success') setMessages(messages);
@@ -54,7 +54,7 @@ export default function OrderMessages() {
     const token = localStorage.getItem('auth_token');
     try {
       const { status } = await post(
-        `/order/consumer/message/send/${orderId}`,
+        `/consumer/orders/${orderId}/message`,
         { message: newMessage.trim() },
         { token }
       );

--- a/src/pages/Otp.jsx
+++ b/src/pages/Otp.jsx
@@ -28,8 +28,11 @@ export default function Otp() {
         body: JSON.stringify({ phone: '+91' + phone, otp }),
       });
       const data = await res.json();
-      if (data.status === 'success' && data.auth_token) {
-        localStorage.setItem('auth_token', data.auth_token);
+      if (data.status === 'success' && data.access_token) {
+        localStorage.setItem('auth_token', `Bearer ${data.access_token}`);
+        if (data.refresh_token) {
+          localStorage.setItem('refresh_token', data.refresh_token);
+        }
         if (data.basic_onboarding_done) {
           navigate('/home');
         } else {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -25,7 +25,7 @@ export default function Profile() {
 
   async function fetchProfile() {
     try {
-      const { status, data } = await get('/profile/me', { token: localStorage.getItem('auth_token') });
+      const { status, data } = await get('/consumer/profile/me', { token: localStorage.getItem('auth_token') });
       if (status === 'success') {
         setProfile(data);
         setEditData(data);
@@ -49,7 +49,7 @@ export default function Profile() {
 
   async function saveEdit() {
     try {
-      const { status, message } = await post('/profile/edit', editData, { token: localStorage.getItem('auth_token') });
+      const { status, message } = await post('/consumer/profile/edit', editData, { token: localStorage.getItem('auth_token') });
       if (status === 'success') {
         setProfile(editData);
         setEditing(false);
@@ -66,8 +66,9 @@ export default function Profile() {
     if (!window.confirm('Logout?')) return;
     try {
       await post('/logout', {}, { token: localStorage.getItem('auth_token') });
-    } catch {}
+    } catch { /* ignore */ }
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('refresh_token');
     navigate('/login');
   }
 

--- a/src/pages/RateOrder.jsx
+++ b/src/pages/RateOrder.jsx
@@ -27,7 +27,7 @@ export default function RateOrder() {
 
   async function fetchOrder(token) {
     try {
-      const { status, orders } = await get('/order/history', { token });
+      const { status, orders } = await get('/consumer/order/history', { token });
       if (status === 'success') {
         const o = orders.find(o => o.order_id === +orderId);
         if (o) {
@@ -52,7 +52,7 @@ export default function RateOrder() {
     setSubmitting(true);
     const token = localStorage.getItem('auth_token');
     try {
-      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/order/rate/${orderId}`, {
+      const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/consumer/orders/${orderId}/rate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/ReturnOrder.jsx
+++ b/src/pages/ReturnOrder.jsx
@@ -31,7 +31,7 @@ export default function ReturnOrder() {
 
   async function fetchOrder() {
     try {
-      const { status, orders } = await get('/order/history', {
+      const { status, orders } = await get('/consumer/order/history', {
         token: localStorage.getItem('auth_token')
       });
       if (status === 'success') {
@@ -79,10 +79,11 @@ export default function ReturnOrder() {
         item_id: Number(item_id),
         quantity
       }));
-      const { status, message } = await post(`/order/return/raise/${orderId}`, {
-        token: localStorage.getItem('auth_token'),
-        body: { items, reason: reason.trim() }
-      });
+      const { status, message } = await post(
+        `/consumer/orders/${orderId}/return/raise`,
+        { items, reason: reason.trim() },
+        { token: localStorage.getItem('auth_token') }
+      );
       if (status === 'success') {
         alert('Return request sent successfully.');
         navigate(`/order/${orderId}`);

--- a/src/pages/SearchShops.jsx
+++ b/src/pages/SearchShops.jsx
@@ -29,7 +29,7 @@ export default function SearchShops() {
     setLoading(true);
     try {
       const token = localStorage.getItem('auth_token');
-      const { status, shops } = await get(`/shops/search?q=${encodeURIComponent(q)}`, { token });
+      const { status, shops } = await get(`/consumer/shops/search?q=${encodeURIComponent(q)}`, { token });
       if (status === 'success') {
         setShops(shops);
         const updated = [q, ...recent.filter(r => r !== q)].slice(0, 5);

--- a/src/pages/ShopDetail.jsx
+++ b/src/pages/ShopDetail.jsx
@@ -29,7 +29,7 @@ export default function ShopDetails() {
 
   async function fetchShopItems() {
     try {
-      const res = await fetch(`${backendUrl}/items/shop/${shopId}`, {
+      const res = await fetch(`${backendUrl}/shop/${shopId}/items`, {
         headers: { Authorization: token },
       });
       const data = await res.json();
@@ -39,7 +39,7 @@ export default function ShopDetails() {
       } else {
         alert('Failed to load shop items');
       }
-    } catch (error) {
+    } catch {
       alert('Something went wrong. Please try again.');
     }
     setLoading(false);
@@ -47,19 +47,19 @@ export default function ShopDetails() {
 
   async function fetchCartCount() {
     try {
-      const res = await fetch(`${backendUrl}/cart/view`, {
+      const res = await fetch(`${backendUrl}/consumer/cart/view`, {
         headers: { Authorization: token },
       });
       const data = await res.json();
       if (data.status === 'success') {
         setCartCount(data.cart.length);
       }
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   async function addToCart(itemId) {
     try {
-      const res = await fetch(`${backendUrl}/cart/add`, {
+      const res = await fetch(`${backendUrl}/consumer/cart/add`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/ShopList.jsx
+++ b/src/pages/ShopList.jsx
@@ -31,8 +31,8 @@ export default function ShopList() {
     setLoading(true);
     try {
       const url = filterType
-        ? `/shops?type=${filterType}`
-        : '/shops';
+        ? `/consumer/shops?type=${filterType}`
+        : '/consumer/shops';
       const { status, shops: data } = await get(url, { token });
       setShops(status === 'success' ? data : []);
     } catch {

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -44,7 +44,7 @@ export default function Wallet() {
 
   async function fetchWallet(token) {
     try {
-      const { status, balance } = await get('/wallet', { token });
+      const { status, balance } = await get('/consumer/wallet', { token });
       if (status === 'success') setBalance(balance);
     } catch {
       // fail silent
@@ -53,7 +53,7 @@ export default function Wallet() {
 
   async function fetchTransactions(token) {
     try {
-      const { status, transactions } = await get('/wallet/history', { token });
+      const { status, transactions } = await get('/consumer/wallet/history', { token });
       if (status === 'success') setTransactions(transactions.slice(0, 5));
     } catch {
       // fail silent

--- a/src/pages/WalletHistory.jsx
+++ b/src/pages/WalletHistory.jsx
@@ -43,7 +43,7 @@ export default function WalletHistory() {
 
   async function fetchTransactions(token) {
     try {
-      const { status, transactions } = await get('/wallet/history', { token });
+      const { status, transactions } = await get('/consumer/wallet/history', { token });
       if (status === 'success') setTransactions(transactions);
     } catch {
       // fail silent


### PR DESCRIPTION
## Summary
- point frontend at `/api/v1` backend and switch routes to new consumer endpoints
- handle OTP login using `access_token` and store refresh token
- update wallets, carts, orders, shops and profile calls to new `/consumer/...` paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68920b6a29cc8333a6d46451cb34537c